### PR TITLE
create Input Field component with props and HTML attributes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import './App.css';
 import { FaBeer } from 'react-icons/fa';
+// import Input from './components/Input';
 
 function App() {
   return (
@@ -7,6 +8,11 @@ function App() {
       <h1 className='text-6xl'>
         hej <FaBeer />
       </h1>
+     {/* <Input 
+        id="test"
+        name="test" 
+        label="Test Input"
+      /> */}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import './App.css';
 import { FaBeer } from 'react-icons/fa';
-// import Input from './components/Input';
 
 function App() {
   return (
@@ -8,11 +7,6 @@ function App() {
       <h1 className='text-6xl'>
         hej <FaBeer />
       </h1>
-     {/* <Input 
-        id="test"
-        name="test" 
-        label="Test Input"
-      /> */}
     </>
   );
 }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,40 @@
+import type { FC, InputHTMLAttributes } from 'react';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+     name: string;
+     label: string;
+     id: string;
+}
+
+const Input: FC<InputProps> = ({ name, label, id }) => {
+     return (
+          <div className="flex flex-col gap-2 w-100">
+               <label
+                    htmlFor={id}
+                    className="text-text-dark font-family text-sm"
+               >
+                    {label}
+               </label>
+               <input
+                    id={id}
+                    name={name}
+                    placeholder={name}
+                    className="
+                         px-3 py-2 
+                         bg-surface   
+                         border border-border 
+                         rounded-2xl
+                         text-text-dark
+                         placeholder:text-able
+                         focus:outline-none 
+                         focus:border-focus 
+                         focus:ring-focus focus:ring-1 focus:ring-focus
+                         cursor-text   
+                         disabled:cursor-not-allowed       
+               "
+               />
+          </div>
+     )
+}
+
+export default Input

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -11,7 +11,7 @@ const Input: FC<InputProps> = ({ name, label, id }) => {
           <div className="flex flex-col gap-2 w-100">
                <label
                     htmlFor={id}
-                    className="text-text-dark font-family text-sm"
+                    className="text-text-dark text-sm"
                >
                     {label}
                </label>
@@ -28,7 +28,7 @@ const Input: FC<InputProps> = ({ name, label, id }) => {
                          placeholder:text-able
                          focus:outline-none 
                          focus:border-focus 
-                         focus:ring-focus focus:ring-1 focus:ring-focus
+                         focus:ring-focus focus:ring-1
                          cursor-text   
                          disabled:cursor-not-allowed       
                "


### PR DESCRIPTION
Skapad en återanvändbar Input-komponent med TypeScript som är fullt integrerad med vårt tema-system.

## Props
```typescript
interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
  name: string;     // Input name attribut
  label: string;    // Label text
  id: string;       // Unique identifier
}