### PR TITLE
Add interactive map with route visualitatuib 

### DIFF
--- a/src/components/Driver/MapComponent.tsx
+++ b/src/components/Driver/MapComponent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -40,7 +40,11 @@ interface RouteInfo {
      duration: number;
 }
 
-const MapComponent = () => {
+interface MapComponentProps {
+     onRouteLoaded?: (openInGoogleMaps: () => void) => void;
+}
+
+const MapComponent = ({ onRouteLoaded }: MapComponentProps) => {
      const [routeData, setRouteData] = useState<RouteData | null>(null);
      const [routeInfo, setRouteInfo] = useState<RouteInfo | null>(null);
      const [loading, setLoading] = useState(true);
@@ -71,6 +75,22 @@ const MapComponent = () => {
 
           loadData();
      }, []);
+
+     const openInGoogleMaps = useCallback(() => {
+          if (!routeData) return;
+
+          const { startPoint, endPoint } = routeData;
+
+          const googleMapsUrl = `https://www.google.com/maps/dir/?api=1&origin=${startPoint.lat},${startPoint.lng}&destination=${endPoint.lat},${endPoint.lng}&travelmode=driving`;
+
+          window.open(googleMapsUrl, '_blank');
+     }, [routeData]);
+     useEffect(() => {
+          if (routeData && onRouteLoaded) {
+               onRouteLoaded(openInGoogleMaps);
+          }
+     }, [routeData, onRouteLoaded, openInGoogleMaps]);
+
 
      const calculateRoute = async (data: RouteData) => {
           try {
@@ -116,7 +136,7 @@ const MapComponent = () => {
 
      if (loading) {
           return (
-               <div className="w-full h-64 flex items-center justify-center bg-gray-100 rounded">
+               <div className="w-full h-64 flex items-center justify-center bg-background rounded">
                     <p>Laddar karta...</p>
                </div>
           );
@@ -124,7 +144,7 @@ const MapComponent = () => {
 
      if (error || !routeData || !routeInfo) {
           return (
-               <div className="w-full h-64 flex items-center justify-center bg-gray-100 rounded">
+               <div className="w-full h-64 flex items-center justify-center bg-background rounded">
                     <p className="text-red-600">Fel: {error || 'Data inte tillgänglig'}</p>
                </div>
           );
@@ -138,14 +158,14 @@ const MapComponent = () => {
      return (
           <div className="w-full space-y-2">
                {routeInfo.distance > 0 && (
-                    <div className="bg-background text-dark p-3 rounded shadow-sm text-sm">
+                    <div className="mb-3 bg-background text-dark p-3 rounded shadow-sm text-sm">
                          <span className="font-semibold">Distans:</span> {(routeInfo.distance / 1000).toFixed(1)} km
                          <span className="mx-3">|</span>
                          <span className="font-semibold">Beräknad tid:</span> {Math.round(routeInfo.duration / 60)} min
                     </div>
                )}
 
-               <div className="w-full h-64 rounded overflow-hidden shadow">
+               <div className="w-full h-70 rounded overflow-hidden shadow">
                     <MapContainer
                          center={center}
                          zoom={7}

--- a/src/components/Driver/MapComponent.tsx
+++ b/src/components/Driver/MapComponent.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -20,40 +21,165 @@ L.Icon.Default.mergeOptions({
 
 L.Marker.prototype.options.icon = DefaultIcon;
 
-const MapComponent = () => {
-     const center: [number, number] = [57.7089, 11.9746];
+interface RouteData {
+     startPoint: {
+          lat: number;
+          lng: number;
+          name?: string;
+     };
+     endPoint: {
+          lat: number;
+          lng: number;
+          name?: string;
+     };
+}
 
-     const routePoints: [number, number][] = [
-          [55.6051, 13.0038], // Malmö 
-          [57.7089, 11.9746]  // Göteborg
+interface RouteInfo {
+     coordinates: [number, number][];
+     distance: number;
+     duration: number;
+}
+
+const MapComponent = () => {
+     const [routeData, setRouteData] = useState<RouteData | null>(null);
+     const [routeInfo, setRouteInfo] = useState<RouteInfo | null>(null);
+     const [loading, setLoading] = useState(true);
+     const [error, setError] = useState<string | null>(null);
+
+     useEffect(() => {
+          const loadData = async () => {
+               try {
+                    // Simulerar datahämtning med en timeout
+                    // när API finns: ersätt denna del med fetch!!!
+                    await new Promise(resolve => setTimeout(resolve, 500));
+
+                    const mockData: RouteData = {
+                         startPoint: { lat: 55.6051, lng: 13.0038, name: 'Malmö' },
+                         endPoint: { lat: 57.7089, lng: 11.9746, name: 'Göteborg' }
+                    };
+
+                    setRouteData(mockData);
+                    await calculateRoute(mockData);
+
+               } catch (err) {
+                    setError(err instanceof Error ? err.message : 'Okänt fel');
+                    console.error('Fel:', err);
+               } finally {
+                    setLoading(false);
+               }
+          };
+
+          loadData();
+     }, []);
+
+     const calculateRoute = async (data: RouteData) => {
+          try {
+               const { startPoint, endPoint } = data;
+               /**
+                * Hämtar ruttinformation från OSRM API för att beräkna vägen mellan två punkter.
+                * Använder OSRM:s routing-tjänst för att få detaljerad geometri i GeoJSON-format.
+                * 
+                * @description Skickar en HTTP GET-förfrågan till OSRM Project för att få körriktningar
+                * mellan start- och slutpunkt med full översikt och GeoJSON-geometrier
+                */
+               const response = await fetch(
+                    `https://router.project-osrm.org/route/v1/driving/${startPoint.lng},${startPoint.lat};${endPoint.lng},${endPoint.lat}?overview=full&geometries=geojson`
+               );
+
+               const osrmData = await response.json();
+
+               if (osrmData.routes && osrmData.routes[0]) {
+                    const route = osrmData.routes[0];
+
+                    const coordinates: [number, number][] = route.geometry.coordinates.map(
+                         (coord: number[]) => [coord[1], coord[0]]
+                    );
+
+                    setRouteInfo({
+                         coordinates,
+                         distance: route.distance,
+                         duration: route.duration
+                    });
+               }
+          } catch (err) {
+               console.error('Fel vid ruttberäkning:', err);
+               setRouteInfo({
+                    coordinates: [
+                         [data.startPoint.lat, data.startPoint.lng],
+                         [data.endPoint.lat, data.endPoint.lng]
+                    ],
+                    distance: 0,
+                    duration: 0
+               });
+          }
+     };
+
+     if (loading) {
+          return (
+               <div className="w-full h-64 flex items-center justify-center bg-gray-100 rounded">
+                    <p>Laddar karta...</p>
+               </div>
+          );
+     }
+
+     if (error || !routeData || !routeInfo) {
+          return (
+               <div className="w-full h-64 flex items-center justify-center bg-gray-100 rounded">
+                    <p className="text-red-600">Fel: {error || 'Data inte tillgänglig'}</p>
+               </div>
+          );
+     }
+
+     const center: [number, number] = [
+          (routeData.startPoint.lat + routeData.endPoint.lat) / 2,
+          (routeData.startPoint.lng + routeData.endPoint.lng) / 2
      ];
 
      return (
-          <div className="w-full h-64 rounded-2xl overflow-hidden">
-               <MapContainer
-                    center={center}
-                    zoom={10}
-                    style={{ height: '100%', width: '100%' }}
-               >
-                    <TileLayer
-                         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-                    />
+          <div className="w-full space-y-2">
+               {routeInfo.distance > 0 && (
+                    <div className="bg-background text-dark p-3 rounded shadow-sm text-sm">
+                         <span className="font-semibold">Distans:</span> {(routeInfo.distance / 1000).toFixed(1)} km
+                         <span className="mx-3">|</span>
+                         <span className="font-semibold">Beräknad tid:</span> {Math.round(routeInfo.duration / 60)} min
+                    </div>
+               )}
 
-                    <Marker position={routePoints[0]}>
-                         <Popup>Startpunkt</Popup>
-                    </Marker>
+               <div className="w-full h-64 rounded overflow-hidden shadow">
+                    <MapContainer
+                         center={center}
+                         zoom={7}
+                         style={{ height: '100%', width: '100%' }}
+                    >
+                         <TileLayer
+                              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                         />
 
-                    <Marker position={routePoints[1]}>
-                         <Popup>Slutpunkt</Popup>
-                    </Marker>
+                         <Marker position={[routeData.startPoint.lat, routeData.startPoint.lng]}>
+                              <Popup>
+                                   <strong>Startpunkt</strong>
+                                   <br />
+                                   {routeData.startPoint.name}
+                              </Popup>
+                         </Marker>
 
-                    <Polyline
-                         positions={routePoints}
-                         color="var(--color-success)"
-                         weight={3}
-                    />
-               </MapContainer>
+                         <Marker position={[routeData.endPoint.lat, routeData.endPoint.lng]}>
+                              <Popup>
+                                   <strong>Slutpunkt</strong>
+                                   <br />
+                                   {routeData.endPoint.name}
+                              </Popup>
+                         </Marker>
+
+                         <Polyline
+                              positions={routeInfo.coordinates}
+                              color="var(--color-success)"
+                              weight={4}
+                              opacity={0.7}
+                         />
+                    </MapContainer>
+               </div>
           </div>
      );
 };

--- a/src/components/Driver/MapComponent.tsx
+++ b/src/components/Driver/MapComponent.tsx
@@ -5,18 +5,16 @@ import 'leaflet/dist/leaflet.css';
 
 const DefaultIcon = L.icon({
      iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
-     shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
      iconSize: [25, 41],
      iconAnchor: [12, 41],
      popupAnchor: [1, -34],
-     shadowSize: [41, 41]
+
 });
 
 delete (L.Icon.Default.prototype as L.Icon.Default & { _getIconUrl?: () => string })._getIconUrl;
 L.Icon.Default.mergeOptions({
      iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
      iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
-     shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
 });
 
 L.Marker.prototype.options.icon = DefaultIcon;

--- a/src/components/Driver/NavigationCard.tsx
+++ b/src/components/Driver/NavigationCard.tsx
@@ -2,7 +2,17 @@ import { useState } from 'react';
 import { PrimaryButton } from '../PrimaryButton';
 import MapComponent from './MapComponent';
 
-const NavigationCard = () => {
+interface NavigationCardProps {
+  firstButtonText: string;
+  secondButtonText: string;
+  onSecondButtonClick: () => void;
+}
+
+const NavigationCard = ({ 
+  firstButtonText, 
+  secondButtonText, 
+  onSecondButtonClick 
+}: NavigationCardProps) => {
   const [openGoogleMaps, setOpenGoogleMaps] = useState<(() => void) | null>(null);
 
   const handleRouteLoaded = (openMapsFn: () => void) => {
@@ -15,7 +25,7 @@ const NavigationCard = () => {
       
       <div className="flex gap-2 justify-center mb-4 p-4">
         <PrimaryButton
-          text="Visa Rutt"
+          text={firstButtonText}
           onClick={() => {
             if (openGoogleMaps) {
               openGoogleMaps();

--- a/src/components/Driver/NavigationCard.tsx
+++ b/src/components/Driver/NavigationCard.tsx
@@ -20,8 +20,8 @@ const NavigationCard = ({
   };
 
   return (
-    <div className="bg-secondary/80 rounded-2xl p-4">
-      <h3 className="font-semibold text-lg text-dark mb-4">Navigation</h3>
+    <div className="bg-secondary rounded p-4">
+      <h3 className="font-bold text-lg text-dark mb-4">Navigation</h3>
       
       <div className="flex gap-2 justify-center mb-4 p-4">
         <PrimaryButton

--- a/src/components/Driver/NavigationCard.tsx
+++ b/src/components/Driver/NavigationCard.tsx
@@ -1,7 +1,14 @@
+import { useState } from 'react';
 import { PrimaryButton } from '../PrimaryButton';
 import MapComponent from './MapComponent';
 
 const NavigationCard = () => {
+  const [openGoogleMaps, setOpenGoogleMaps] = useState<(() => void) | null>(null);
+
+  const handleRouteLoaded = (openMapsFn: () => void) => {
+    setOpenGoogleMaps(() => openMapsFn);
+  };
+
   return (
     <div className="bg-secondary/80 rounded-2xl p-4">
       <h3 className="font-semibold text-text-dark mb-4">Navigation</h3>
@@ -9,7 +16,13 @@ const NavigationCard = () => {
       <div className="flex gap-2 justify-center mb-4 scale-125 p-4">
         <PrimaryButton
           text="Visa Rutt"
-          onClick={() => alert('Rutt!')}
+          onClick={() => {
+            if (openGoogleMaps) {
+              openGoogleMaps();
+            } else {
+              alert('Rutten laddas fortfarande...');
+            }
+          }}
         />
         
         <PrimaryButton
@@ -18,7 +31,7 @@ const NavigationCard = () => {
         />
       </div>
 
-      <MapComponent />
+      <MapComponent onRouteLoaded={handleRouteLoaded} />
     </div>
   );
 };

--- a/src/pages/Driver.tsx
+++ b/src/pages/Driver.tsx
@@ -14,7 +14,7 @@ import { useNavigate } from "react-router-dom";
 
       <div className="relative z-10 min-h-screen">
         <h1 className="text-3xl font-bold text-dark bg-secondary p-5">
-          Förar Dashboard
+          Förare Dashboard
         </h1>
 
         <div className="p-4 space-y-6 pb-20">

--- a/src/pages/Driver.tsx
+++ b/src/pages/Driver.tsx
@@ -45,7 +45,6 @@ import { useNavigate } from "react-router-dom";
           <NavigationCard
             firstButtonText="Visa rutt"
             secondButtonText="Lista paket"
-            onFirstButtonClick={() => alert('Visar rutt!')}
             onSecondButtonClick={() => navigate('/package-list')}
           />
         </div>

--- a/src/pages/Driver.tsx
+++ b/src/pages/Driver.tsx
@@ -5,13 +5,13 @@ import { PrimaryButton } from "../components/PrimaryButton";
 import BottomNav from "../components/BottomNav";
 import { useNavigate } from "react-router-dom";
 
-const Driver = () => {
+  const Driver = () => {
   const navigate = useNavigate();
 
   return (
     <div className="relative min-h-screen">
 
-      {/* Content overlay with semi-transparent background */}
+
       <div className="relative z-10 min-h-screen">
         <h1 className="text-3xl font-bold text-dark bg-secondary p-5">
           Förar Dashboard


### PR DESCRIPTION
## 📝 Beskrivning

Lagt till interaktiv karta som visar rutt mellan två punkter med avstånd och restid. Användaren kan öppna rutten direkt i Google Maps.

## 🔧 Ändringar

- `MapComponent` visar karta med Leaflet och beräknar rutt via OSRM API
- `NavigationCard` visar två knappar och kartan
- Lagt till funktion för att öppna rutten i Google Maps
- Just nu används mock-data (Malmö → Göteborg), ska kopplas till riktig API senare

## ℹ️ Ytterligare information

OSRM (Open Source Routing Machine) används för ruttberäkning istället för Google Maps API för att hålla kostnaderna nere. Mock-data finns på rad 42 i MapComponent - ersätt med fetch när API:et är klart.
