### PR TITLE
Get packages from api on Sender page

### DIFF
--- a/src/pages/sender/Sender.tsx
+++ b/src/pages/sender/Sender.tsx
@@ -1,12 +1,37 @@
-import { FaPiggyBank } from "react-icons/fa";
+import { FaBomb, FaBox, FaHourglass, FaReceipt, FaTruck } from "react-icons/fa";
 import BackArrow from "../../components/BackArrow";
-import { FaWandSparkles } from "react-icons/fa6";
 import { PrimaryButton } from "../../components/PrimaryButton";
 import Card from "../../components/Card";
 import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
 
 export function Sender() {
   const navigate = useNavigate();
+
+  const [packages, setPackages] = useState([] as ApiPackage[]);
+
+  useEffect(() => {
+    async function loadPackages() {
+      const response = await fetch(
+        "https://team9testwebapp-h3b5c7gqgbeqhxgp.swedencentral-01.azurewebsites.net/api/packages"
+      );
+      const data = await response.json();
+      setPackages(data.packages);
+    }
+    loadPackages();
+  }, []);
+
+  const packageCards = packages.map((p: ApiPackage) => (
+    <Card
+      destination={p.Destination}
+      fordonId={p.DriverID + " " + p.DriverName}
+      key={p.PackageID}
+      paketId={p.PackageID.toString()}
+      status={p.Status}
+      variant="package"
+      vikt={p.PackageWeight.toString()}
+    />
+  ));
 
   return (
     <main className="flex flex-col p-8 gap-8 max-w-4xl mx-auto">
@@ -20,59 +45,64 @@ export function Sender() {
       <div className="flex flex-col gap-8 bg-white/75 p-4 m-[-1rem] rounded-b-3xl rounded-t-2xl mb-1">
         <section className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <div>
-            {" "}
-            <FaPiggyBank /> <span> 0</span> <span>Totalt paket</span>
+            <FaBox /> <span>{packages.length}</span>
+            <span> paket totalt</span>
           </div>
           <div>
-            {" "}
-            <FaPiggyBank /> <span> 0</span> <span>Totalt paket</span>
+            <FaReceipt />{" "}
+            <span>
+              {packages.filter((p) => p.Status == "Registered").length}
+            </span>
+            <span> registrerade paket</span>
           </div>
           <div>
-            {" "}
-            <FaPiggyBank /> <span> 0</span> <span>Totalt paket</span>
+            <FaHourglass />{" "}
+            <span>{packages.filter((p) => p.Status == "Pending").length}</span>{" "}
+            <span> väntande paket</span>
           </div>
           <div>
-            {" "}
-            <FaPiggyBank /> <span> 0</span> <span>Totalt paket</span>
+            <FaTruck />{" "}
+            <span>{packages.filter((p) => p.Status == "Transit").length}</span>{" "}
+            <span> paket på väg</span>
           </div>
         </section>
         <section>
-          <FaWandSparkles /> Du har 1 aktiv varning som behöver hanteras.
+          <FaBomb /> Du har{" "}
+          {packages.filter((p) => p.Status == "Warning").length || "ingen"}{" "}
+          aktiv varning som behöver hanteras.
         </section>
         <PrimaryButton
           text="+ Skapa nytt paket"
           onClick={() => navigate("/sender/new")}
-          // onClick={() => navigate("new")}
         />
       </div>
       <div className="flex flex-col gap-8 bg-white/75 p-4 m-[-1rem] rounded-b-3xl rounded-t-2xl">
         <div className="flex justify-left items-baseline gap-4">
           <h2 className="text-2xl">Mina paket</h2>
-          <span>3 paket</span>
+          <span>{packages.length > 0 ? packages.length + " paket" : ""}</span>
         </div>
-        <Card
-          variant="package"
-          destination="Svenska Livs AB"
-          paketId="PKG-123"
-          status="OK"
-        />
-        <Card
-          variant="package"
-          destination="Svenska Livs AB"
-          paketId="PKG-123"
-        />
-        <Card
-          variant="package"
-          destination="Svenska Livs AB"
-          paketId="PKG-123"
-          status="Kritisk"
-        />
-        <Card
-          variant="package"
-          destination="Svenska Livs AB"
-          paketId="PKG-123"
-        />
+        {/* // TODO Visa laddar paket... före laddat och inga paket om 0 st */}
+        {packageCards}
       </div>
     </main>
   );
 }
+
+type ApiPackage = {
+  Destination: string;
+  DriverID: number;
+  DriverName: string;
+  GPSLatitude: number | null;
+  GPSLongitude: number | null;
+  Origin: string;
+  PackageDepth: number;
+  PackageHeight: number;
+  PackageID: number;
+  PackageWeight: number;
+  PackageWidth: number;
+  ReceiverID: number;
+  ReceiverName: string;
+  SenderID: number;
+  SenderName: string;
+  Status: "Registered" | "Pending" | "Transit" | "Delivered" | "Warning";
+};


### PR DESCRIPTION


## 📝 Beskrivning

Fixat så lista med paket hämtas från api. Fixat så att siffrorna över antalet paket funkar.

## 🔧 Ändringar

-  GET /api/packages
- Visa alla paket med Card
- Siffror över antal paket
- Bättre ikoner

## ℹ️ Ytterligare information

<img width="359" height="705" alt="image" src="https://github.com/user-attachments/assets/d639a388-6493-45d9-9ee2-93bdedaf9799" />
